### PR TITLE
Implement async CRUD layer and migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = alembic_migrations
+sqlalchemy.url = sqlite+aiosqlite:///./tele_store.db
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic_migrations/__init__.py
+++ b/alembic_migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic migration package."""

--- a/alembic_migrations/env.py
+++ b/alembic_migrations/env.py
@@ -1,0 +1,89 @@
+"""Alembic environment configured for asynchronous SQLAlchemy engine."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from logging.config import fileConfig
+from typing import TYPE_CHECKING
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
+
+# Подготавливаем переменные окружения до импорта настроек приложения.
+config = context.config
+
+
+def _ensure_env_defaults() -> None:
+    """Назначить значения переменных окружения для импорта."""
+    default_database_url = config.get_main_option(
+        "sqlalchemy.url", "sqlite+aiosqlite:///./tele_store.db"
+    )
+    os.environ.setdefault("BOT_TOKEN", "migration-placeholder-token")
+    os.environ.setdefault("ADMINS", "1")
+    os.environ.setdefault("DATABASE_URL", default_database_url)
+
+
+_ensure_env_defaults()
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Импортируем базу и модели только после установки переменных окружения.
+from tele_store.db.db import Base  # noqa: E402
+from tele_store.models import models as _models  # noqa: F401,E402
+
+target_metadata = Base.metadata
+
+
+def get_url() -> str:
+    """Получить URL базы данных из переменных окружения или конфигурации."""
+    return os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+
+
+def run_migrations_offline() -> None:
+    """Запустить миграции в офлайн-режиме."""
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    """Выполнить миграции для предоставленного соединения."""
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Асинхронно запустить миграции в режиме online."""
+    connectable: AsyncEngine = create_async_engine(get_url(), poolclass=pool.NullPool)
+
+    try:
+        async with connectable.begin() as connection:
+            await connection.run_sync(do_run_migrations)
+    finally:
+        await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Точка входа Alembic для режима online."""
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic_migrations/script.py.mako
+++ b/alembic_migrations/script.py.mako
@@ -1,0 +1,16 @@
+"""Generic single-database configuration."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+${imports if imports else ""}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic_migrations/versions/202501070001_create_initial_schema.py
+++ b/alembic_migrations/versions/202501070001_create_initial_schema.py
@@ -1,0 +1,188 @@
+"""Create initial database schema"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "202501070001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+order_status_enum = sa.Enum(
+    "new", "processing", "shipped", "delivered", "canceled", name="order_status"
+)
+
+
+def upgrade() -> None:
+    order_status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=True),
+        sa.Column("phone", sa.String(length=32), nullable=True),
+        sa.Column("address", sa.Text(), nullable=True),
+    )
+
+    op.create_table(
+        "categories",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=128), nullable=False, unique=True),
+        sa.Column("description", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_categories_name", "categories", ["name"], unique=False)
+
+    op.create_table(
+        "products",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("category_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("price", sa.Numeric(10, 2), nullable=False),
+        sa.Column("photo_file_id", sa.String(length=255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.CheckConstraint("price >= 0", name="price_non_negative"),
+        sa.ForeignKeyConstraint(
+            ["category_id"], ["categories.id"], ondelete="RESTRICT"
+        ),
+    )
+    op.create_index(
+        "ix_products_category_id", "products", ["category_id"], unique=False
+    )
+    op.create_index("ix_products_name", "products", ["name"], unique=False)
+
+    op.create_table(
+        "carts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.BigInteger(), nullable=False, unique=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_carts_user_id", "carts", ["user_id"], unique=True)
+
+    op.create_table(
+        "cart_items",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("cart_id", sa.Integer(), nullable=False),
+        sa.Column("product_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "quantity",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.CheckConstraint("quantity > 0", name="quantity_positive"),
+        sa.UniqueConstraint(
+            "cart_id", "product_id", name="uq_cartitem_cart_product"
+        ),
+        sa.ForeignKeyConstraint(["cart_id"], ["carts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"], ondelete="RESTRICT"),
+    )
+    op.create_index("ix_cart_items_cart_id", "cart_items", ["cart_id"], unique=False)
+    op.create_index(
+        "ix_cart_items_product_id", "cart_items", ["product_id"], unique=False
+    )
+    op.create_index(
+        "ix_cart_items_cart_product",
+        "cart_items",
+        ["cart_id", "product_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "orders",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("order_number", sa.String(length=32), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "total_price",
+            sa.Numeric(12, 2),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("delivery_method", sa.String(length=64), nullable=True),
+        sa.Column("status", order_status_enum, nullable=False, server_default="new"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint("total_price >= 0", name="total_price_non_negative"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+    )
+    op.create_index(
+        "ix_orders_order_number", "orders", ["order_number"], unique=True
+    )
+    op.create_index("ix_orders_user_id", "orders", ["user_id"], unique=False)
+
+    op.create_table(
+        "order_items",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("product_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "quantity",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("price", sa.Numeric(10, 2), nullable=False),
+        sa.CheckConstraint("quantity > 0", name="orderitem_qty_positive"),
+        sa.CheckConstraint("price >= 0", name="orderitem_price_non_negative"),
+        sa.UniqueConstraint(
+            "order_id", "product_id", name="uq_orderitem_order_product"
+        ),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"], ondelete="RESTRICT"),
+    )
+    op.create_index(
+        "ix_order_items_order_id", "order_items", ["order_id"], unique=False
+    )
+    op.create_index(
+        "ix_order_items_product_id", "order_items", ["product_id"], unique=False
+    )
+    op.create_index(
+        "ix_order_items_order_product",
+        "order_items",
+        ["order_id", "product_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_order_items_order_product", table_name="order_items")
+    op.drop_index("ix_order_items_product_id", table_name="order_items")
+    op.drop_index("ix_order_items_order_id", table_name="order_items")
+    op.drop_table("order_items")
+
+    op.drop_index("ix_orders_user_id", table_name="orders")
+    op.drop_index("ix_orders_order_number", table_name="orders")
+    op.drop_table("orders")
+
+    op.drop_index("ix_cart_items_cart_product", table_name="cart_items")
+    op.drop_index("ix_cart_items_product_id", table_name="cart_items")
+    op.drop_index("ix_cart_items_cart_id", table_name="cart_items")
+    op.drop_table("cart_items")
+
+    op.drop_index("ix_carts_user_id", table_name="carts")
+    op.drop_table("carts")
+
+    op.drop_index("ix_products_name", table_name="products")
+    op.drop_index("ix_products_category_id", table_name="products")
+    op.drop_table("products")
+
+    op.drop_index("ix_categories_name", table_name="categories")
+    op.drop_table("categories")
+
+    op.drop_table("users")
+
+    order_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/alembic_migrations/versions/__init__.py
+++ b/alembic_migrations/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Container for Alembic revision scripts."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ ruff = "^0.13.1"
 mypy = "^1.18.2"
 alembic = "^1.16.5"
 pytest = "^8.4.2"
+pytest-asyncio = "^0.24.0"
 
 [tool.ruff]
 line-length = 88

--- a/tele_store/__main__.py
+++ b/tele_store/__main__.py
@@ -4,9 +4,12 @@ import logging
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
-from config.config_reader import config
-from handlers import setup_routers
-from models import init_all_databases
+
+from tele_store.config.config_reader import config
+from tele_store.handlers import setup_routers
+from tele_store.models import init_all_databases
+
+logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
@@ -26,6 +29,6 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        logging.info("Bot stopped by user")
-    except Exception as e:
-        logging.exception("Unhandled exception: %s", e)
+        logger.info("Bot stopped by user")
+    except Exception:
+        logger.exception("Unhandled exception")

--- a/tele_store/crud/__init__.py
+++ b/tele_store/crud/__init__.py
@@ -1,0 +1,547 @@
+"""
+Асинхронные CRUD-функции для всех моделей проекта.
+
+Модуль содержит высокоуровневые обёртки над базовыми операциями
+SQLAlchemy. Каждая функция принимает экземпляр :class:`AsyncSession`
+и возвращает ORM-объекты, полностью подготовленные к дальнейшему
+использованию. Все функции снабжены докстрингами и неявно коммитят
+изменения, чтобы минимизировать количество шаблонного кода в хендлерах
+Telegram-бота.
+
+Функции сгруппированы по доменным моделям и реализуют базовый набор
+операций: создание, получение, обновление и удаление (CRUD). Дополнительно
+добавлены функции для выборки связанных данных (например, товаров корзины
+или заказов пользователя).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import selectinload
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+from tele_store.db.enums import OrderStatus
+from tele_store.models.models import (
+    Cart,
+    CartItem,
+    Category,
+    Order,
+    OrderItem,
+    Product,
+    User,
+)
+
+
+def _filter_fields(
+    allowed: Iterable[str], values: Mapping[str, object]
+) -> dict[str, object]:
+    """Вернуть только разрешённые поля из входного словаря."""
+    allowed_set = set(allowed)
+    return {key: value for key, value in values.items() if key in allowed_set}
+
+
+# --------------------------- Пользователи ---------------------------
+
+
+async def create_user(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    name: str | None = None,
+    phone: str | None = None,
+    address: str | None = None,
+) -> User:
+    """
+    Создать пользователя.
+
+    ``id`` пользователя совпадает с Telegram ID, поэтому значение
+    передаётся явно.
+    """
+    user = User(id=user_id, name=name, phone=phone, address=address)
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def get_user(session: AsyncSession, user_id: int) -> User | None:
+    """Получить пользователя по идентификатору."""
+    return await session.get(User, user_id)
+
+
+async def list_users(
+    session: AsyncSession,
+    *,
+    limit: int | None = None,
+    offset: int = 0,
+) -> list[User]:
+    """Вернуть список пользователей, упорядоченный по идентификатору."""
+    stmt: Select[tuple[User]] = select(User).order_by(User.id).offset(offset)
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_user(
+    session: AsyncSession, user_id: int, **fields: object
+) -> User | None:
+    """
+    Обновить данные пользователя.
+
+    Поддерживаются поля ``name``, ``phone`` и ``address``. Если переданы
+    другие значения, они будут проигнорированы.
+    """
+    user = await session.get(User, user_id)
+    if user is None:
+        return None
+
+    updates = _filter_fields({"name", "phone", "address"}, fields)
+    for attr, value in updates.items():
+        setattr(user, attr, value)
+
+    if updates:
+        await session.commit()
+        await session.refresh(user)
+    return user
+
+
+async def delete_user(session: AsyncSession, user_id: int) -> bool:
+    """Удалить пользователя вместе с его корзиной и заказами."""
+    user = await session.get(User, user_id)
+    if user is None:
+        return False
+
+    await session.delete(user)
+    await session.commit()
+    return True
+
+
+# --------------------------- Категории ---------------------------
+
+
+async def create_category(
+    session: AsyncSession, *, name: str, description: str | None = None
+) -> Category:
+    """Создать новую категорию товаров."""
+    category = Category(name=name, description=description)
+    session.add(category)
+    await session.commit()
+    await session.refresh(category)
+    return category
+
+
+async def get_category(session: AsyncSession, category_id: int) -> Category | None:
+    """Получить категорию по идентификатору."""
+    return await session.get(Category, category_id)
+
+
+async def list_categories(session: AsyncSession) -> list[Category]:
+    """Вернуть все категории, отсортированные по имени."""
+    result = await session.execute(select(Category).order_by(Category.name))
+    return list(result.scalars().all())
+
+
+async def update_category(
+    session: AsyncSession, category_id: int, **fields: object
+) -> Category | None:
+    """Обновить имя или описание категории."""
+    category = await session.get(Category, category_id)
+    if category is None:
+        return None
+
+    updates = _filter_fields({"name", "description"}, fields)
+    for attr, value in updates.items():
+        setattr(category, attr, value)
+
+    if updates:
+        await session.commit()
+        await session.refresh(category)
+    return category
+
+
+async def delete_category(session: AsyncSession, category_id: int) -> bool:
+    """Удалить категорию вместе со связанными товарами."""
+    category = await session.get(Category, category_id)
+    if category is None:
+        return False
+
+    await session.delete(category)
+    await session.commit()
+    return True
+
+
+# --------------------------- Товары ---------------------------
+
+
+async def create_product(
+    session: AsyncSession,
+    *,
+    category_id: int,
+    name: str,
+    price: Decimal,
+    description: str | None = None,
+    photo_file_id: str | None = None,
+    is_active: bool = True,
+) -> Product:
+    """Создать товар и привязать его к категории."""
+    product = Product(
+        category_id=category_id,
+        name=name,
+        description=description,
+        price=price,
+        photo_file_id=photo_file_id,
+        is_active=is_active,
+    )
+    session.add(product)
+    await session.commit()
+    await session.refresh(product)
+    return product
+
+
+async def get_product(session: AsyncSession, product_id: int) -> Product | None:
+    """Получить товар по идентификатору вместе с категорией."""
+    stmt = (
+        select(Product)
+        .where(Product.id == product_id)
+        .options(selectinload(Product.category))
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_products(
+    session: AsyncSession,
+    *,
+    category_id: int | None = None,
+    only_active: bool = True,
+) -> list[Product]:
+    """Вернуть список товаров, опционально отфильтрованных по категории."""
+    stmt: Select[tuple[Product]] = select(Product).order_by(Product.name)
+    if category_id is not None:
+        stmt = stmt.where(Product.category_id == category_id)
+    if only_active:
+        stmt = stmt.where(Product.is_active.is_(True))
+
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_product(
+    session: AsyncSession, product_id: int, **fields: object
+) -> Product | None:
+    """Обновить информацию о товаре."""
+    product = await session.get(Product, product_id)
+    if product is None:
+        return None
+
+    updates = _filter_fields(
+        {
+            "category_id",
+            "name",
+            "description",
+            "price",
+            "photo_file_id",
+            "is_active",
+        },
+        fields,
+    )
+    for attr, value in updates.items():
+        setattr(product, attr, value)
+
+    if updates:
+        await session.commit()
+        await session.refresh(product)
+    return product
+
+
+async def delete_product(session: AsyncSession, product_id: int) -> bool:
+    """Удалить товар. Связанные элементы корзины удаляются каскадно."""
+    product = await session.get(Product, product_id)
+    if product is None:
+        return False
+
+    await session.delete(product)
+    await session.commit()
+    return True
+
+
+# --------------------------- Корзины ---------------------------
+
+
+async def create_cart(session: AsyncSession, *, user_id: int) -> Cart:
+    """Создать корзину пользователя."""
+    cart = Cart(user_id=user_id)
+    session.add(cart)
+    await session.commit()
+    await session.refresh(cart)
+    return cart
+
+
+async def get_cart(session: AsyncSession, cart_id: int) -> Cart | None:
+    """Получить корзину по её идентификатору вместе с товарами."""
+    stmt = (
+        select(Cart)
+        .where(Cart.id == cart_id)
+        .options(selectinload(Cart.items).selectinload(CartItem.product))
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_cart_by_user(session: AsyncSession, user_id: int) -> Cart | None:
+    """Найти корзину пользователя по идентификатору пользователя."""
+    stmt = (
+        select(Cart)
+        .where(Cart.user_id == user_id)
+        .options(selectinload(Cart.items).selectinload(CartItem.product))
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def delete_cart(session: AsyncSession, cart_id: int) -> bool:
+    """Удалить корзину и связанные элементы."""
+    cart = await session.get(Cart, cart_id)
+    if cart is None:
+        return False
+
+    await session.delete(cart)
+    await session.commit()
+    return True
+
+
+async def list_cart_items(session: AsyncSession, cart_id: int) -> list[CartItem]:
+    """Вернуть содержимое корзины."""
+    stmt = (
+        select(CartItem)
+        .where(CartItem.cart_id == cart_id)
+        .options(selectinload(CartItem.product))
+        .order_by(CartItem.id)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+# --------------------------- Элементы корзины ---------------------------
+
+
+async def create_cart_item(
+    session: AsyncSession,
+    *,
+    cart_id: int,
+    product_id: int,
+    quantity: int = 1,
+) -> CartItem:
+    """Добавить товар в корзину."""
+    cart_item = CartItem(cart_id=cart_id, product_id=product_id, quantity=quantity)
+    session.add(cart_item)
+    await session.commit()
+    await session.refresh(cart_item)
+    return cart_item
+
+
+async def update_cart_item(
+    session: AsyncSession, cart_item_id: int, *, quantity: int | None = None
+) -> CartItem | None:
+    """Обновить количество товара в корзине."""
+    cart_item = await session.get(CartItem, cart_item_id)
+    if cart_item is None:
+        return None
+
+    if quantity is not None:
+        cart_item.quantity = quantity
+        await session.commit()
+        await session.refresh(cart_item)
+    return cart_item
+
+
+async def delete_cart_item(session: AsyncSession, cart_item_id: int) -> bool:
+    """Удалить товар из корзины."""
+    cart_item = await session.get(CartItem, cart_item_id)
+    if cart_item is None:
+        return False
+
+    await session.delete(cart_item)
+    await session.commit()
+    return True
+
+
+# --------------------------- Заказы ---------------------------
+
+
+async def create_order(
+    session: AsyncSession,
+    *,
+    order_number: str,
+    user_id: int | None = None,
+    total_price: Decimal = Decimal(0),
+    delivery_method: str | None = None,
+    status: OrderStatus = OrderStatus.NEW,
+) -> Order:
+    """Создать заказ."""
+    order = Order(
+        order_number=order_number,
+        user_id=user_id,
+        total_price=total_price,
+        delivery_method=delivery_method,
+        status=status,
+    )
+    session.add(order)
+    await session.commit()
+    await session.refresh(order)
+    return order
+
+
+async def get_order(session: AsyncSession, order_id: int) -> Order | None:
+    """Получить заказ вместе с позициями и данными пользователя."""
+    stmt = (
+        select(Order)
+        .where(Order.id == order_id)
+        .options(
+            selectinload(Order.items).selectinload(OrderItem.product),
+            selectinload(Order.user),
+        )
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_orders(
+    session: AsyncSession,
+    *,
+    user_id: int | None = None,
+    status: OrderStatus | None = None,
+) -> list[Order]:
+    """Вернуть список заказов с возможностью фильтрации."""
+    stmt: Select[tuple[Order]] = select(Order).order_by(Order.created_at.desc())
+    if user_id is not None:
+        stmt = stmt.where(Order.user_id == user_id)
+    if status is not None:
+        stmt = stmt.where(Order.status == status)
+
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_order(
+    session: AsyncSession, order_id: int, **fields: object
+) -> Order | None:
+    """Обновить информацию о заказе."""
+    order = await session.get(Order, order_id)
+    if order is None:
+        return None
+
+    updates = _filter_fields(
+        {"order_number", "user_id", "total_price", "delivery_method", "status"},
+        fields,
+    )
+    for attr, value in updates.items():
+        setattr(order, attr, value)
+
+    if updates:
+        await session.commit()
+        await session.refresh(order)
+    return order
+
+
+async def delete_order(session: AsyncSession, order_id: int) -> bool:
+    """Удалить заказ и все его позиции."""
+    order = await session.get(Order, order_id)
+    if order is None:
+        return False
+
+    await session.delete(order)
+    await session.commit()
+    return True
+
+
+async def count_orders_by_status(
+    session: AsyncSession, status: OrderStatus
+) -> int:
+    """Подсчитать количество заказов в заданном статусе."""
+    status_subquery = select(Order.id).where(Order.status == status).subquery()
+    stmt = select(func.count()).select_from(status_subquery)
+    result = await session.execute(stmt)
+    return int(result.scalar_one())
+
+
+# --------------------------- Позиции заказа ---------------------------
+
+
+async def create_order_item(
+    session: AsyncSession,
+    *,
+    order_id: int,
+    product_id: int,
+    quantity: int,
+    price: Decimal,
+) -> OrderItem:
+    """Создать позицию заказа."""
+    order_item = OrderItem(
+        order_id=order_id,
+        product_id=product_id,
+        quantity=quantity,
+        price=price,
+    )
+    session.add(order_item)
+    await session.commit()
+    await session.refresh(order_item)
+    return order_item
+
+
+async def get_order_item(
+    session: AsyncSession, order_item_id: int
+) -> OrderItem | None:
+    """Получить позицию заказа по идентификатору."""
+    return await session.get(OrderItem, order_item_id)
+
+
+async def list_order_items(session: AsyncSession, order_id: int) -> list[OrderItem]:
+    """Получить все позиции конкретного заказа."""
+    stmt = (
+        select(OrderItem)
+        .where(OrderItem.order_id == order_id)
+        .options(selectinload(OrderItem.product))
+        .order_by(OrderItem.id)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_order_item(
+    session: AsyncSession,
+    order_item_id: int,
+    **fields: object,
+) -> OrderItem | None:
+    """Обновить количество или цену позиции заказа."""
+    order_item = await session.get(OrderItem, order_item_id)
+    if order_item is None:
+        return None
+
+    updates = _filter_fields({"quantity", "price"}, fields)
+    for attr, value in updates.items():
+        setattr(order_item, attr, value)
+
+    if updates:
+        await session.commit()
+        await session.refresh(order_item)
+    return order_item
+
+
+async def delete_order_item(session: AsyncSession, order_item_id: int) -> bool:
+    """Удалить позицию заказа."""
+    order_item = await session.get(OrderItem, order_item_id)
+    if order_item is None:
+        return False
+
+    await session.delete(order_item)
+    await session.commit()
+    return True

--- a/tele_store/db/db.py
+++ b/tele_store/db/db.py
@@ -1,4 +1,5 @@
-from config.config_reader import config
+import sqlite3
+
 from sqlalchemy import MetaData, event
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
@@ -6,6 +7,8 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.orm import DeclarativeBase
+
+from tele_store.config.config_reader import config
 
 DATABASE_URL = config.DATABASE_URL
 
@@ -21,7 +24,9 @@ db_sessionmaker = async_sessionmaker(db_engine, expire_on_commit=False)
 
 
 @event.listens_for(db_engine.sync_engine, "connect")
-def set_sqlite_pragma(dbapi_connection, connection_record) -> None:
+def set_sqlite_pragma(
+    dbapi_connection: sqlite3.Connection, _connection_record: object
+) -> None:
     cursor = dbapi_connection.cursor()
     cursor.execute("PRAGMA journal_mode=WAL;")
     cursor.execute("PRAGMA synchronous=NORMAL;")

--- a/tele_store/filters/__init__.py
+++ b/tele_store/filters/__init__.py
@@ -1,0 +1,1 @@
+"""Filters used in the bot."""

--- a/tele_store/filters/admin_filter.py
+++ b/tele_store/filters/admin_filter.py
@@ -1,8 +1,12 @@
 from aiogram.filters import BaseFilter
 from aiogram.types import Message
-from config.config_reader import config
+
+from tele_store.config.config_reader import config
 
 
 class IsAdmin(BaseFilter):
+    """Проверяет, является ли пользователь администратором."""
+
     async def __call__(self, message: Message) -> bool:
+        """Вернуть ``True``, если отправитель сообщения в списке админов."""
         return message.from_user.id in config.ADMINS

--- a/tele_store/handlers/__init__.py
+++ b/tele_store/handlers/__init__.py
@@ -1,10 +1,10 @@
 from aiogram import Router
 
+from tele_store.handlers.command import start_command_router
+
 
 def setup_routers() -> Router:
-    from .command import start_command_router
-
+    """Создать и настроить основной роутер."""
     router = Router()
     router.include_routers(start_command_router.router)
-
     return router

--- a/tele_store/handlers/command/__init__.py
+++ b/tele_store/handlers/command/__init__.py
@@ -1,0 +1,1 @@
+"""Command handlers for the bot."""

--- a/tele_store/handlers/command/start_command_router.py
+++ b/tele_store/handlers/command/start_command_router.py
@@ -3,19 +3,20 @@ import logging
 from aiogram import Router
 from aiogram.filters import Command, CommandObject, CommandStart
 from aiogram.types import Message
-from filters.admin_filter import IsAdmin
+
+from tele_store.filters.admin_filter import IsAdmin
 
 router = Router()
 logger = logging.getLogger(__name__)
 
 
 @router.message(CommandStart())
-async def start_command(message: Message, command: CommandObject) -> None:
+async def start_command(message: Message, _command: CommandObject) -> None:
     user_name = message.from_user.first_name
     await message.answer(f"Привет, {user_name}")
 
 
 @router.message(IsAdmin(), Command("admin"))
-async def admin_command(message: Message, command: CommandObject) -> None:
+async def admin_command(message: Message, _command: CommandObject) -> None:
     admin_name = message.from_user.first_name
     await message.answer(f"Привет, {admin_name}")

--- a/tele_store/models/__init__.py
+++ b/tele_store/models/__init__.py
@@ -1,7 +1,8 @@
+from tele_store.db.db import Base, db_engine
+from tele_store.models import models as _models  # noqa: F401
+
+
 async def init_all_databases() -> None:
     """Создание таблиц в базе данных по описанию моделей."""
-    import models.models  # noqa: F401
-    from db.db import Base, db_engine
-
     async with db_engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)

--- a/tele_store/models/models.py
+++ b/tele_store/models/models.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from datetime import datetime  # noqa: TC003
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from db.db import Base
-from db.enums import OrderStatus
 from sqlalchemy import (
     BigInteger,
     CheckConstraint,
@@ -22,8 +22,10 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from tele_store.db.db import Base
+from tele_store.db.enums import OrderStatus
+
 if TYPE_CHECKING:
-    from datetime import datetime
     from decimal import Decimal
 
 convention = {
@@ -49,6 +51,7 @@ class User(Base):
     )
 
     def __repr__(self) -> str:
+        """Строковое представление пользователя для отладки."""
         return f"<User id={self.id} name={self.name!r}>"
 
 
@@ -64,6 +67,7 @@ class Category(Base):
     )
 
     def __repr__(self) -> str:
+        """Строковое представление категории."""
         return f"<Category id={self.id} name={self.name!r}>"
 
 
@@ -89,6 +93,7 @@ class Product(Base):
     __table_args__ = (CheckConstraint("price >= 0", name="price_non_negative"),)
 
     def __repr__(self) -> str:
+        """Строковое представление товара."""
         return f"<Product id={self.id} name={self.name!r} price={self.price}>"
 
 
@@ -109,6 +114,7 @@ class Cart(Base):
     )
 
     def __repr__(self) -> str:
+        """Строковое представление корзины."""
         return f"<Cart id={self.id} user_id={self.user_id}>"
 
 
@@ -134,7 +140,11 @@ class CartItem(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<CartItem cart_id={self.cart_id} product_id={self.product_id} qty={self.quantity}>"
+        """Строковое представление позиции корзины."""
+        return (
+            f"<CartItem cart_id={self.cart_id} "
+            f"product_id={self.product_id} qty={self.quantity}>"
+        )
 
 
 class Order(Base):
@@ -172,7 +182,11 @@ class Order(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<Order id={self.id} user_id={self.user_id} status={self.status} total={self.total_price}>"
+        """Строковое представление заказа."""
+        return (
+            f"<Order id={self.id} user_id={self.user_id} "
+            f"status={self.status} total={self.total_price}>"
+        )
 
 
 class OrderItem(Base):
@@ -201,4 +215,8 @@ class OrderItem(Base):
     )
 
     def __repr__(self) -> str:
-        return f"<OrderItem order_id={self.order_id} product_id={self.product_id} qty={self.quantity} price={self.price}>"
+        """Строковое представление позиции заказа."""
+        return (
+            f"<OrderItem order_id={self.order_id} "
+            f"product_id={self.product_id} qty={self.quantity} price={self.price}>"
+        )

--- a/tele_store/states/__init__.py
+++ b/tele_store/states/__init__.py
@@ -1,0 +1,1 @@
+"""State definitions for FSM."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Общие фикстуры для тестов CRUD и миграций."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+from alembic.config import Config
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from alembic import command
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+# Значения по умолчанию позволяют импортировать модули настроек приложения.
+os.environ.setdefault("BOT_TOKEN", "TEST_TOKEN")
+os.environ.setdefault("ADMINS", "[1]")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_alembic_config(database_url: str) -> Config:
+    """Создать конфигурацию Alembic для указанного URL."""
+    cfg = Config(str(PROJECT_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(PROJECT_ROOT / "alembic_migrations"))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    cfg.attributes["configure_logger"] = False
+    return cfg
+
+
+@pytest.fixture(scope="session")
+def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """Предоставить отдельный цикл событий для pytest-asyncio."""
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def migrated_database(tmp_path: Path) -> Iterator[str]:
+    """Создать чистую тестовую базу данных и применить миграции Alembic."""
+    db_file = tmp_path / "test.sqlite3"
+    database_url = f"sqlite+aiosqlite:///{db_file.as_posix()}"
+    os.environ["DATABASE_URL"] = database_url
+
+    cfg = _make_alembic_config(database_url)
+    command.upgrade(cfg, "head")
+
+    try:
+        yield database_url
+    finally:
+        command.downgrade(cfg, "base")
+        if db_file.exists():
+            db_file.unlink()
+
+
+@pytest_asyncio.fixture
+async def session(migrated_database: str) -> AsyncIterator[AsyncSession]:
+    """Подключиться к тестовой базе и вернуть асинхронную сессию."""
+    engine: AsyncEngine = create_async_engine(migrated_database, future=True)
+    async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with async_session() as db_session:
+            yield db_session
+    finally:
+        await engine.dispose()

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,182 @@
+"""Тесты, проверяющие CRUD-операции для всех моделей проекта."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tele_store import crud
+from tele_store.db.enums import OrderStatus
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_user_crud(session: AsyncSession) -> None:
+    user = await crud.create_user(session, user_id=123, name="Alice")
+    assert user.id == 123
+    assert user.name == "Alice"
+
+    fetched = await crud.get_user(session, user.id)
+    assert fetched is not None
+    assert fetched.phone is None
+
+    updated = await crud.update_user(
+        session, user.id, phone="+100200", address="Main street, 1"
+    )
+    assert updated is not None
+    assert updated.phone == "+100200"
+    assert updated.address == "Main street, 1"
+
+    missing_update = await crud.update_user(session, 999, name="Ghost")
+    assert missing_update is None
+
+    users = await crud.list_users(session)
+    assert [u.id for u in users] == [123]
+
+    assert await crud.delete_user(session, user.id) is True
+    assert await crud.delete_user(session, user.id) is False
+
+
+@pytest.mark.asyncio
+async def test_category_and_product_crud(session: AsyncSession) -> None:
+    category = await crud.create_category(
+        session, name="Electronics", description="Devices and gadgets"
+    )
+    assert category.id is not None
+
+    product = await crud.create_product(
+        session,
+        category_id=category.id,
+        name="Smartphone",
+        description="OLED display",
+        price=Decimal("499.90"),
+        photo_file_id="photo_1",
+    )
+    assert product.category_id == category.id
+
+    categories = await crud.list_categories(session)
+    assert len(categories) == 1
+
+    fetched = await crud.get_product(session, product.id)
+    assert fetched is not None
+    assert fetched.category.id == category.id
+
+    updated_product = await crud.update_product(
+        session,
+        product.id,
+        price=Decimal("450.00"),
+        is_active=False,
+    )
+    assert updated_product is not None
+    assert updated_product.price == Decimal("450.00")
+    assert updated_product.is_active is False
+
+    active_products = await crud.list_products(session)
+    assert active_products == []
+
+    all_products = await crud.list_products(session, only_active=False)
+    assert [p.id for p in all_products] == [product.id]
+
+    assert await crud.delete_product(session, product.id) is True
+    assert await crud.delete_product(session, product.id) is False
+
+    assert await crud.delete_category(session, category.id) is True
+    assert await crud.delete_category(session, category.id) is False
+
+
+@pytest.mark.asyncio
+async def test_cart_crud(session: AsyncSession) -> None:
+    user = await crud.create_user(session, user_id=555, name="Bob")
+    category = await crud.create_category(session, name="Books")
+    product = await crud.create_product(
+        session, category_id=category.id, name="Novel", price=Decimal("12.50")
+    )
+
+    cart = await crud.create_cart(session, user_id=user.id)
+    assert cart.user_id == user.id
+
+    cart_item = await crud.create_cart_item(
+        session, cart_id=cart.id, product_id=product.id, quantity=2
+    )
+    assert cart_item.quantity == 2
+
+    items = await crud.list_cart_items(session, cart.id)
+    assert len(items) == 1
+
+    updated_item = await crud.update_cart_item(session, cart_item.id, quantity=5)
+    assert updated_item is not None
+    assert updated_item.quantity == 5
+
+    fetched_cart = await crud.get_cart(session, cart.id)
+    assert fetched_cart is not None
+    assert len(fetched_cart.items) == 1
+
+    fetched_by_user = await crud.get_cart_by_user(session, user.id)
+    assert fetched_by_user is not None
+    assert fetched_by_user.id == cart.id
+
+    assert await crud.delete_cart_item(session, cart_item.id) is True
+    assert await crud.delete_cart_item(session, cart_item.id) is False
+
+    assert await crud.delete_cart(session, cart.id) is True
+    assert await crud.delete_cart(session, cart.id) is False
+
+
+@pytest.mark.asyncio
+async def test_order_crud(session: AsyncSession) -> None:
+    user = await crud.create_user(session, user_id=777, name="Charlie")
+    category = await crud.create_category(session, name="Accessories")
+    product = await crud.create_product(
+        session,
+        category_id=category.id,
+        name="Watch",
+        price=Decimal("199.99"),
+    )
+
+    order = await crud.create_order(
+        session,
+        order_number="ORD-001",
+        user_id=user.id,
+        total_price=Decimal("199.99"),
+        delivery_method="courier",
+    )
+    assert order.status == OrderStatus.NEW
+
+    order_item = await crud.create_order_item(
+        session,
+        order_id=order.id,
+        product_id=product.id,
+        quantity=1,
+        price=Decimal("199.99"),
+    )
+    assert order_item.price == Decimal("199.99")
+
+    items = await crud.list_order_items(session, order.id)
+    assert len(items) == 1
+
+    await crud.update_order_item(session, order_item.id, quantity=3)
+    updated_order_item = await crud.get_order_item(session, order_item.id)
+    assert updated_order_item is not None
+    assert updated_order_item.quantity == 3
+
+    await crud.update_order(session, order.id, status=OrderStatus.PROCESSING)
+    processing_orders = await crud.list_orders(session, status=OrderStatus.PROCESSING)
+    assert [o.id for o in processing_orders] == [order.id]
+
+    counter = await crud.count_orders_by_status(session, OrderStatus.PROCESSING)
+    assert counter == 1
+
+    fetched_order = await crud.get_order(session, order.id)
+    assert fetched_order is not None
+    assert len(fetched_order.items) == 1
+    assert fetched_order.user.id == user.id
+
+    assert await crud.delete_order_item(session, order_item.id) is True
+    assert await crud.delete_order_item(session, order_item.id) is False
+
+    assert await crud.delete_order(session, order.id) is True
+    assert await crud.delete_order(session, order.id) is False


### PR DESCRIPTION
## Summary
- add a documented async CRUD module covering users, categories, products, carts, and orders
- configure Alembic with an initial schema migration and rename the migrations folder to avoid package conflicts
- introduce async testing fixtures and CRUD tests while normalizing package imports and adding missing package initializers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1718168e8832ab6ac50fe72f52b57