### PR TITLE
Add user order flow with category and product selection

### DIFF
--- a/tele_store/handlers/__init__.py
+++ b/tele_store/handlers/__init__.py
@@ -2,7 +2,7 @@ from aiogram import Router
 
 from tele_store.handlers.callback import admin_callbacks, callbacks, user_callbacks
 from tele_store.handlers.command import admin_command_router, start_command_router
-from tele_store.handlers.message import admin_message
+from tele_store.handlers.message import admin_message, user_message
 
 
 def setup_routers() -> Router:
@@ -16,6 +16,7 @@ def setup_routers() -> Router:
         user_callbacks.router,
         callbacks.router,
         admin_message.router,
+        user_message.router,
     ]
 
     for r in routers:

--- a/tele_store/handlers/callback/user_callbacks.py
+++ b/tele_store/handlers/callback/user_callbacks.py
@@ -1,18 +1,276 @@
+from __future__ import annotations
+
 import logging
+import secrets
+from typing import TYPE_CHECKING
 
 from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery
-from sqlalchemy.ext.asyncio import AsyncSession
 
+from tele_store.crud.category import CategoryManager
+from tele_store.crud.order import OrderManager
 from tele_store.crud.product import ProductManager
-from tele_store.keyboards.inline.catalog_list_menu import get_catalog_list_menu_keyboard
+from tele_store.keyboards.inline.cancel_button import cancel_key
+from tele_store.keyboards.inline.product_order_menu import product_order_keyboard
+from tele_store.keyboards.inline.user_category_menu import get_user_category_keyboard
+from tele_store.keyboards.inline.user_product_menu import get_user_product_keyboard
+from tele_store.schemas.order import CreateOrder, CreateOrderItem
+from tele_store.states.states import RegNewUser
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 router = Router()
 logger = logging.getLogger(__name__)
 
 
-@router.callback_query(F.data == "test")
-async def open_catalog(call: CallbackQuery, session: AsyncSession) -> None: 
-    """Открыть каталог товаров"""
+def generate_order_number() -> str:
+    """Сгенерировать короткий номер заказа."""
+
+    return secrets.token_hex(4).upper()
+
+
+@router.callback_query(F.data == "catalog")
+async def open_catalog(call: CallbackQuery, session: AsyncSession) -> None:
+    """Показать пользователю список категорий."""
+
+    keyboard, total = await get_user_category_keyboard(session=session)
+
+    if total == 0:
+        await call.answer("Категории пока не добавлены.", show_alert=True)
+        return
+
     await call.answer()
-    await call.message.answer()
+    await call.message.answer("📂 Выберите категорию:", reply_markup=keyboard)
+
+
+@router.callback_query(F.data == "back_to_categories")
+async def back_to_categories(call: CallbackQuery, session: AsyncSession) -> None:
+    """Вернуться к списку категорий."""
+
+    keyboard, total = await get_user_category_keyboard(session=session)
+
+    if total == 0:
+        await call.answer("Категории пока недоступны.", show_alert=True)
+        return
+
+    await call.answer()
+
+    try:
+        await call.message.edit_reply_markup()
+    except Exception:
+        logger.debug("Не удалось очистить клавиатуру сообщения", exc_info=True)
+
+    await call.message.answer("📂 Выберите категорию:", reply_markup=keyboard)
+
+
+@router.callback_query(F.data.startswith("user_category_page:"))
+async def paginate_categories(call: CallbackQuery, session: AsyncSession) -> None:
+    """Переключение страниц списка категорий."""
+
+    page = int(call.data.split(":")[1])
+    keyboard, total = await get_user_category_keyboard(session=session, page=page)
+
+    if total == 0:
+        await call.answer("Категории пока отсутствуют.", show_alert=True)
+        return
+
+    await call.message.edit_reply_markup(reply_markup=keyboard)
+    await call.answer()
+
+
+@router.callback_query(F.data.startswith("user_category:"))
+async def open_category(call: CallbackQuery, session: AsyncSession) -> None:
+    """Показать товары выбранной категории."""
+
+    _, category_id_raw, *_ = call.data.split(":")
+    category_id = int(category_id_raw)
+
+    category = await CategoryManager.get_category(session=session, category_id=category_id)
+
+    if category is None:
+        await call.answer("Категория не найдена.", show_alert=True)
+        return
+
+    keyboard, total = await get_user_product_keyboard(
+        session=session, category_id=category_id
+    )
+
+    if total == 0:
+        await call.answer("В этой категории пока нет товаров.", show_alert=True)
+        return
+
+    await call.answer()
+    await call.message.answer(
+        f"🛍 <b>{category.name}</b>\nВыберите товар для оформления заказа:",
+        reply_markup=keyboard,
+    )
+
+
+@router.callback_query(F.data.startswith("user_product_page:"))
+async def paginate_products(call: CallbackQuery, session: AsyncSession) -> None:
+    """Переключение страниц товаров внутри категории."""
+
+    _, category_raw, page_raw = call.data.split(":")
+    category_id = int(category_raw)
+    page = int(page_raw)
+
+    keyboard, total = await get_user_product_keyboard(
+        session=session, category_id=category_id, page=page
+    )
+
+    if total == 0:
+        await call.answer("В этой категории пока нет товаров.", show_alert=True)
+        return
+
+    await call.message.edit_reply_markup(reply_markup=keyboard)
+    await call.answer()
+
+
+@router.callback_query(F.data.startswith("user_product:"))
+async def show_product_preview(call: CallbackQuery, session: AsyncSession) -> None:
+    """Показать карточку товара с предложением оформить заказ."""
+
+    _, product_raw, category_raw, page_raw = call.data.split(":")
+    product_id = int(product_raw)
+    category_id = int(category_raw)
+    page = int(page_raw)
+
+    product = await ProductManager.get_product(session=session, product_id=product_id)
+
+    if product is None or not product.is_active:
+        await call.answer("Товар недоступен.", show_alert=True)
+        return
+
+    caption = (
+        f"📦 <b>{product.name}</b>\n"
+        f"💵 Цена: {product.price} ₽\n"
+        f"📜 Описание: {product.description or '—'}"
+    )
+
+    keyboard = product_order_keyboard(
+        category_id=category_id, product_id=product.id, page=page
+    )
+
+    if product.photo_file_id:
+        await call.message.answer_photo(
+            product.photo_file_id,
+            caption=caption,
+            reply_markup=keyboard,
+        )
+    else:
+        await call.message.answer(caption, reply_markup=keyboard)
+
+    await call.answer()
+
+
+@router.callback_query(F.data == "cart")
+async def open_cart(call: CallbackQuery) -> None:
+    """Сообщить пользователю о временном отсутствии корзины."""
+
+    await call.answer("Корзина будет доступна позже.", show_alert=True)
+
+
+@router.callback_query(F.data == "cancel_order")
+async def cancel_order(call: CallbackQuery, state: FSMContext) -> None:
+    """Отменить оформление заказа на этапе подтверждения."""
+
+    if await state.get_state() == RegNewUser.confirm.state:
+        await state.clear()
+    await call.message.edit_text("❌ Оформление заказа отменено.")
+    await call.answer()
+
+
+@router.callback_query(F.data.startswith("order_product:"))
+async def start_order(
+    call: CallbackQuery, session: AsyncSession, state: FSMContext
+) -> None:
+    """Запустить процесс оформления заказа для выбранного товара."""
+
+    product_id = int(call.data.split(":")[1])
+    product = await ProductManager.get_product(session=session, product_id=product_id)
+
+    if product is None or not product.is_active:
+        await call.answer("Товар недоступен для заказа.", show_alert=True)
+        return
+
+    await state.clear()
+    await state.set_state(RegNewUser.name)
+    await state.update_data(
+        product_id=product.id,
+        product_name=product.name,
+        product_price=str(product.price),
+    )
+
+    await call.message.answer(
+        "Отличный выбор! Давай оформим заказ. Как к тебе обращаться?",
+        reply_markup=cancel_key(),
+    )
+    await call.answer()
+
+
+@router.callback_query(RegNewUser.confirm, F.data == "confirm_order")
+async def confirm_order(
+    call: CallbackQuery, session: AsyncSession, state: FSMContext
+) -> None:
+    """Подтвердить заказ и сохранить его в базе."""
+
+    data = await state.get_data()
+    product_id_raw = data.get("product_id")
+    if product_id_raw is None:
+        await state.clear()
+        await call.message.edit_text(
+            "❌ Не удалось оформить заказ. Попробуйте выбрать товар ещё раз."
+        )
+        await call.answer(show_alert=True)
+        return
+
+    product_id = int(product_id_raw)
+    product = await ProductManager.get_product(session=session, product_id=product_id)
+
+    if product is None or not product.is_active:
+        await state.clear()
+        await call.message.edit_text(
+            "❌ Не удалось оформить заказ: выбранный товар больше недоступен."
+        )
+        await call.answer(show_alert=True)
+        return
+
+    order_number = generate_order_number()
+    price: Decimal = product.price
+
+    order_payload = CreateOrder(
+        order_number=order_number,
+        tg_id=call.from_user.id,
+        total_price=price,
+        delivery_method=data.get("delivery_method"),
+    )
+
+    order = await OrderManager.create_order(session=session, payload=order_payload)
+
+    order_item_payload = CreateOrderItem(
+        order_id=order.id,
+        product_id=product.id,
+        quantity=1,
+        price=price,
+    )
+
+    await OrderManager.create_order_item(session=session, payload=order_item_payload)
+
+    summary = (
+        "✅ <b>Заказ оформлен!</b>\n\n"
+        f"Номер заказа: <code>{order_number}</code>\n"
+        f"Товар: {product.name}\n"
+        f"Стоимость: {price} ₽\n\n"
+        f"Имя: {data.get('name')}\n"
+        f"Телефон: {data.get('phone_number')}\n"
+        f"Адрес: {data.get('address')}\n"
+        f"Доставка: {data.get('delivery_method')}\n\n"
+        "Мы свяжемся с вами в ближайшее время для уточнения деталей."
+    )
+
+    await call.message.edit_text(summary)
+    await state.clear()
+    await call.answer("Заказ успешно создан!", show_alert=True)

--- a/tele_store/handlers/message/user_message.py
+++ b/tele_store/handlers/message/user_message.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from aiogram.fsm.context import FSMContext
+from aiogram.types import Message
+from aiogram import Router
+
+from tele_store.keyboards.inline.cancel_button import cancel_key
+from tele_store.keyboards.inline.order_confirm_menu import order_confirm_keyboard
+from tele_store.states.states import RegNewUser
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+
+@router.message(RegNewUser.name)
+async def process_order_name(message: Message, state: FSMContext) -> None:
+    """Запросить имя покупателя."""
+
+    name = message.text.strip()
+    if not name:
+        await message.answer(
+            "❌ Имя не может быть пустым. Введите его ещё раз:",
+            reply_markup=cancel_key(),
+        )
+        return
+
+    await state.update_data(name=name)
+    await state.set_state(RegNewUser.phone_number)
+    await message.answer(
+        "📞 Теперь укажите номер телефона для связи:",
+        reply_markup=cancel_key(),
+    )
+
+
+@router.message(RegNewUser.phone_number)
+async def process_order_phone(message: Message, state: FSMContext) -> None:
+    """Получить контактный номер пользователя."""
+
+    raw_phone = message.text.strip()
+    digits_only = re.sub(r"\D", "", raw_phone)
+
+    if len(digits_only) < 10 or len(digits_only) > 15:
+        await message.answer(
+            "❌ Похоже, номер введён неверно. Попробуйте снова в формате +79991234567:",
+            reply_markup=cancel_key(),
+        )
+        return
+
+    await state.update_data(phone_number=raw_phone)
+    await state.set_state(RegNewUser.address)
+    await message.answer(
+        "📍 Укажите адрес доставки или пункт самовывоза:",
+        reply_markup=cancel_key(),
+    )
+
+
+@router.message(RegNewUser.address)
+async def process_order_address(message: Message, state: FSMContext) -> None:
+    """Сохранить адрес доставки пользователя."""
+
+    address = message.text.strip()
+    if not address:
+        await message.answer(
+            "❌ Адрес не может быть пустым. Напишите его полностью:",
+            reply_markup=cancel_key(),
+        )
+        return
+
+    await state.update_data(address=address)
+    await state.set_state(RegNewUser.delivery_method)
+    await message.answer(
+        "🚚 Какой способ доставки предпочитаете?", reply_markup=cancel_key()
+    )
+
+
+@router.message(RegNewUser.delivery_method)
+async def process_delivery_method(message: Message, state: FSMContext) -> None:
+    """Получить желаемый метод доставки."""
+
+    delivery_method = message.text.strip()
+    if not delivery_method:
+        await message.answer(
+            "❌ Нужно указать способ доставки. Например: курьером или самовывоз.",
+            reply_markup=cancel_key(),
+        )
+        return
+
+    await state.update_data(delivery_method=delivery_method)
+    await state.set_state(RegNewUser.confirm)
+
+    data = await state.get_data()
+    product_name = data.get("product_name", "—")
+    product_price: Decimal | str | None = data.get("product_price")
+    price_text = str(product_price) if product_price is not None else "—"
+
+    preview = (
+        "📦 <b>Проверьте данные заказа</b>\n\n"
+        f"Товар: {product_name}\n"
+        f"Стоимость: {price_text} ₽\n\n"
+        f"Имя: {data.get('name')}\n"
+        f"Телефон: {data.get('phone_number')}\n"
+        f"Адрес: {data.get('address')}\n"
+        f"Доставка: {delivery_method}\n\n"
+        "Если всё верно — подтвердите оформление."
+    )
+
+    await message.answer(preview, reply_markup=order_confirm_keyboard())

--- a/tele_store/keyboards/inline/order_confirm_menu.py
+++ b/tele_store/keyboards/inline/order_confirm_menu.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def order_confirm_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура подтверждения оформления заказа."""
+
+    builder = InlineKeyboardBuilder()
+
+    builder.row(
+        InlineKeyboardButton(
+            text="✅ Подтвердить заказ",
+            callback_data="confirm_order",
+        )
+    )
+
+    builder.row(
+        InlineKeyboardButton(
+            text="❌ Отменить",
+            callback_data="cancel_order",
+        )
+    )
+
+    return builder.as_markup()

--- a/tele_store/keyboards/inline/product_order_menu.py
+++ b/tele_store/keyboards/inline/product_order_menu.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def product_order_keyboard(
+    *,
+    category_id: int,
+    product_id: int,
+    page: int,
+) -> InlineKeyboardMarkup:
+    """Клавиатура с кнопками для оформления заказа товара."""
+
+    builder = InlineKeyboardBuilder()
+
+    builder.row(
+        InlineKeyboardButton(
+            text="🛍 Оформить заказ",
+            callback_data=f"order_product:{product_id}",
+        )
+    )
+
+    builder.row(
+        InlineKeyboardButton(
+            text="⬅️ Назад к списку",
+            callback_data=f"user_product_page:{category_id}:{page}",
+        )
+    )
+
+    builder.row(
+        InlineKeyboardButton(
+            text="⬅️ К категориям",
+            callback_data="back_to_categories",
+        )
+    )
+
+    builder.row(
+        InlineKeyboardButton(
+            text="❌ Закрыть",
+            callback_data="cancel",
+        )
+    )
+
+    return builder.as_markup()

--- a/tele_store/keyboards/inline/user_category_menu.py
+++ b/tele_store/keyboards/inline/user_category_menu.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from tele_store.config.config_reader import config
+from tele_store.crud.category import CategoryManager
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def get_user_category_keyboard(
+    session: AsyncSession,
+    *,
+    page: int = 1,
+) -> tuple[InlineKeyboardMarkup, int]:
+    """Сформировать клавиатуру с категориями для пользователя."""
+
+    builder = InlineKeyboardBuilder()
+
+    categories = await CategoryManager.list_categories(session=session)
+
+    start = (page - 1) * config.CATEGORIES_PER_PAGE
+    end = start + config.CATEGORIES_PER_PAGE
+    page_categories = categories[start:end]
+
+    for category in page_categories:
+        builder.row(
+            InlineKeyboardButton(
+                text=category.name,
+                callback_data=f"user_category:{category.id}:{page}",
+            )
+        )
+
+    total_pages = (len(categories) + config.CATEGORIES_PER_PAGE - 1) // config.CATEGORIES_PER_PAGE
+    pagination_buttons = []
+
+    if page > 1:
+        pagination_buttons.append(
+            InlineKeyboardButton(
+                text="⬅️ Назад",
+                callback_data=f"user_category_page:{page - 1}",
+            )
+        )
+    if page < total_pages:
+        pagination_buttons.append(
+            InlineKeyboardButton(
+                text="Вперёд ➡️",
+                callback_data=f"user_category_page:{page + 1}",
+            )
+        )
+
+    if pagination_buttons:
+        builder.row(*pagination_buttons)
+
+    builder.row(
+        InlineKeyboardButton(
+            text="❌ Закрыть",
+            callback_data="cancel",
+        )
+    )
+
+    return builder.as_markup(), len(categories)

--- a/tele_store/keyboards/inline/user_product_menu.py
+++ b/tele_store/keyboards/inline/user_product_menu.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from tele_store.config.config_reader import config
+from tele_store.crud.product import ProductManager
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def get_user_product_keyboard(
+    session: AsyncSession,
+    *,
+    category_id: int,
+    page: int = 1,
+) -> tuple[InlineKeyboardMarkup, int]:
+    """Сформировать клавиатуру с товарами выбранной категории."""
+
+    builder = InlineKeyboardBuilder()
+
+    products = await ProductManager.list_products(
+        session=session, category_id=category_id
+    )
+
+    start = (page - 1) * config.ITEMS_PER_PAGE
+    end = start + config.ITEMS_PER_PAGE
+    page_products = products[start:end]
+
+    for product in page_products:
+        builder.row(
+            InlineKeyboardButton(
+                text=f"{product.name} — {product.price} ₽",
+                callback_data=f"user_product:{product.id}:{category_id}:{page}",
+            )
+        )
+
+    total_pages = (len(products) + config.ITEMS_PER_PAGE - 1) // config.ITEMS_PER_PAGE
+    pagination_buttons = []
+
+    if page > 1:
+        pagination_buttons.append(
+            InlineKeyboardButton(
+                text="⬅️ Назад",
+                callback_data=f"user_product_page:{category_id}:{page - 1}",
+            )
+        )
+    if page < total_pages:
+        pagination_buttons.append(
+            InlineKeyboardButton(
+                text="Вперёд ➡️",
+                callback_data=f"user_product_page:{category_id}:{page + 1}",
+            )
+        )
+
+    if pagination_buttons:
+        builder.row(*pagination_buttons)
+
+    builder.row(
+        InlineKeyboardButton(
+            text="⬅️ К категориям",
+            callback_data="back_to_categories",
+        )
+    )
+
+    builder.row(
+        InlineKeyboardButton(
+            text="❌ Закрыть",
+            callback_data="cancel",
+        )
+    )
+
+    return builder.as_markup(), len(products)

--- a/tele_store/schemas/order.py
+++ b/tele_store/schemas/order.py
@@ -7,7 +7,7 @@ from tele_store.db.enums import OrderStatus
 
 class CreateOrder(BaseModel):
     order_number: str
-    user_id: int | None = None
+    tg_id: int | None = None
     total_price: Decimal = Decimal(0)
     delivery_method: str | None = None
     status: OrderStatus = OrderStatus.NEW
@@ -15,7 +15,7 @@ class CreateOrder(BaseModel):
 
 class UpdateOrder(BaseModel):
     order_number: str | None = None
-    user_id: int | None = None
+    tg_id: int | None = None
     total_price: Decimal | None = None
     delivery_method: str | None = None
     status: OrderStatus | None = None


### PR DESCRIPTION
## Summary
- implement inline меню для выбора категорий и товаров пользователем
- добавить хендлеры сообщений и коллбеков для оформления заказа с валидацией данных
- сохранить оформленные заказы и позиции в базе и обновить схему заказа

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d57a62262c832a8d21493e1d91e00e