### PR TITLE
Implement cart-based checkout and admin order status updates

### DIFF
--- a/tele_store/crud/cart.py
+++ b/tele_store/crud/cart.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import selectinload
 
 from tele_store.models.models import Cart, CartItem
@@ -14,96 +14,148 @@ if TYPE_CHECKING:
 
 
 class CartManager:
-    """Класс для управления корзинами пользователей в базе данных"""
+    """Класс для управления корзинами пользователей в базе данных."""
 
     @staticmethod
-    async def create_cart(self: AsyncSession, *, tg_id: int) -> Cart:
+    async def create_cart(session: AsyncSession, *, tg_id: int) -> Cart:
         """Создать корзину пользователя."""
+
         cart = Cart(tg_id=tg_id)
-        self.add(cart)
-        await self.commit()
-        await self.refresh(cart)
+        session.add(cart)
+        await session.commit()
+        await session.refresh(cart)
         return cart
 
     @staticmethod
-    async def get_cart(self: AsyncSession, cart_id: int) -> Cart | None:
+    async def get_cart(session: AsyncSession, cart_id: int) -> Cart | None:
         """Получить корзину по её идентификатору вместе с товарами."""
+
         stmt = (
             select(Cart)
             .where(Cart.id == cart_id)
             .options(selectinload(Cart.items).selectinload(CartItem.product))
         )
-        result = await self.execute(stmt)
+        result = await session.execute(stmt)
         return result.scalar_one_or_none()
 
     @staticmethod
-    async def get_cart_by_user(self: AsyncSession, tg_id: int) -> Cart | None:
+    async def get_cart_by_user(session: AsyncSession, tg_id: int) -> Cart | None:
         """Найти корзину пользователя по идентификатору пользователя."""
+
         stmt = (
             select(Cart)
             .where(Cart.tg_id == tg_id)
             .options(selectinload(Cart.items).selectinload(CartItem.product))
         )
-        result = await self.execute(stmt)
+        result = await session.execute(stmt)
         return result.scalar_one_or_none()
 
     @staticmethod
-    async def delete_cart(self: AsyncSession, cart_id: int) -> bool:
+    async def delete_cart(session: AsyncSession, cart_id: int) -> bool:
         """Удалить корзину и связанные элементы."""
-        cart = await self.get(Cart, cart_id)
+
+        cart = await session.get(Cart, cart_id)
         if cart is None:
             return False
 
-        await self.delete(cart)
-        await self.commit()
+        await session.delete(cart)
+        await session.commit()
         return True
 
     @staticmethod
-    async def list_cart_items(self: AsyncSession, cart_id: int) -> list[CartItem]:
+    async def list_cart_items(session: AsyncSession, cart_id: int) -> list[CartItem]:
         """Вернуть содержимое корзины."""
+
         stmt = (
             select(CartItem)
             .where(CartItem.cart_id == cart_id)
             .options(selectinload(CartItem.product))
             .order_by(CartItem.id)
         )
-        result = await self.execute(stmt)
+        result = await session.execute(stmt)
         return list(result.scalars().all())
 
     @staticmethod
-    async def add_cart_item(self: AsyncSession, *, payload: AddCartItem) -> CartItem:
+    async def get_cart_item(
+        session: AsyncSession, cart_item_id: int
+    ) -> CartItem | None:
+        """Получить конкретный товар из корзины."""
+
+        stmt = (
+            select(CartItem)
+            .where(CartItem.id == cart_item_id)
+            .options(
+                selectinload(CartItem.product), selectinload(CartItem.cart)
+            )
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def get_cart_item_by_product(
+        session: AsyncSession, *, cart_id: int, product_id: int
+    ) -> CartItem | None:
+        """Найти товар в корзине по идентификатору продукта."""
+
+        stmt = (
+            select(CartItem)
+            .where(
+                CartItem.cart_id == cart_id,
+                CartItem.product_id == product_id,
+            )
+            .options(selectinload(CartItem.product))
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def add_cart_item(
+        session: AsyncSession, *, payload: AddCartItem
+    ) -> CartItem:
         """Добавить товар в корзину."""
+
         cart_item = CartItem(
             cart_id=payload.cart_id,
             product_id=payload.product_id,
             quantity=payload.quantity,
         )
-        self.add(cart_item)
-        await self.commit()
-        await self.refresh(cart_item)
+        session.add(cart_item)
+        await session.commit()
+        await session.refresh(cart_item)
         return cart_item
 
     @staticmethod
     async def update_cart_item_count(
-        self: AsyncSession, payload: UpdateCartItemCount
+        session: AsyncSession, payload: UpdateCartItemCount
     ) -> CartItem | None:
         """Обновить количество товара в корзине."""
-        cart_item = await self.get(CartItem, payload.cart_item_id)
+
+        cart_item = await session.get(CartItem, payload.cart_item_id)
         if cart_item is None:
             return None
 
         cart_item.quantity = payload.quantity
-        await self.commit()
-        await self.refresh(cart_item)
+        await session.commit()
+        await session.refresh(cart_item)
         return cart_item
 
     @staticmethod
-    async def delete_cart_item(self: AsyncSession, cart_item_id: int) -> bool:
+    async def delete_cart_item(session: AsyncSession, cart_item_id: int) -> bool:
         """Удалить товар из корзины."""
-        cart_item = await self.get(CartItem, cart_item_id)
+
+        cart_item = await session.get(CartItem, cart_item_id)
         if cart_item is None:
             return False
 
-        await self.delete(cart_item)
-        await self.commit()
+        await session.delete(cart_item)
+        await session.commit()
         return True
+
+    @staticmethod
+    async def clear_cart(session: AsyncSession, cart_id: int) -> None:
+        """Удалить все товары из корзины."""
+
+        await session.execute(
+            delete(CartItem).where(CartItem.cart_id == cart_id)
+        )
+        await session.commit()

--- a/tele_store/handlers/callback/admin_callbacks.py
+++ b/tele_store/handlers/callback/admin_callbacks.py
@@ -1,12 +1,15 @@
 import logging
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 from aiogram import F, Router
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tele_store.crud.category import CategoryManager
+from tele_store.crud.order import OrderManager
 from tele_store.crud.product import ProductManager
 from tele_store.filters.admin_filter import IsAdmin
 from tele_store.keyboards.inline.cancel_button import cancel_key
@@ -17,11 +20,65 @@ from tele_store.keyboards.inline.category_preview_menu import category_preview_k
 from tele_store.keyboards.inline.item_list_menu import get_item_list_menu_keyboard
 from tele_store.keyboards.inline.item_preview_menu import item_preview_key
 from tele_store.keyboards.inline.order_list_menu import get_order_list_menu_keyboard
+from tele_store.keyboards.inline.order_status_menu import (
+    STATUS_TITLES,
+    order_status_keyboard,
+)
+from tele_store.db.enums import OrderStatus
+from tele_store.schemas.order import UpdateOrder
 from tele_store.schemas.product import CreateProduct
 from tele_store.states.states import AddNewCategory, AddNewItem
 
+if TYPE_CHECKING:
+    from tele_store.models.models import Order
+
 router = Router()
 logger = logging.getLogger(__name__)
+
+
+MONEY_STEP = Decimal("0.01")
+
+
+def format_money(amount: Decimal) -> str:
+    """Отформатировать денежную сумму для сообщений."""
+
+    return f"{amount.quantize(MONEY_STEP)} ₽"
+
+
+def build_order_preview_text(order: Order) -> str:
+    """Подготовить текст с подробной информацией о заказе."""
+
+    status_title = STATUS_TITLES.get(order.status, str(order.status))
+    customer = order.user.tg_id if getattr(order, "user", None) else order.tg_id
+    customer_text = str(customer) if customer is not None else "Не указан"
+    delivery_text = order.delivery_method or "Не указана"
+
+    lines: list[str] = []
+    for index, item in enumerate(order.items, start=1):
+        product_name = (
+            item.product.name if getattr(item, "product", None) else f"ID {item.product_id}"
+        )
+        line_total = item.price * item.quantity
+        lines.append(
+            f"{index}. {product_name} — {item.quantity} шт. × "
+            f"{format_money(item.price)} = {format_money(line_total)}"
+        )
+
+    if not lines:
+        lines.append("— товары отсутствуют —")
+
+    items_block = "\n".join(lines)
+
+    return (
+        f"📦 <b>Заказ {order.order_number}</b>\n"
+        f"ID: {order.id}\n"
+        f"Статус: {status_title}\n"
+        f"Покупатель: {customer_text}\n"
+        f"Сумма: {format_money(order.total_price)}\n"
+        f"Доставка: {delivery_text}\n\n"
+        f"Состав заказа:\n{items_block}"
+    )
+
 
 
 @router.callback_query(IsAdmin(), F.data == "add_new_item")
@@ -111,6 +168,101 @@ async def orders_list_handler(call: CallbackQuery, session: AsyncSession) -> Non
 
     keyboard = await get_order_list_menu_keyboard(session=session)
     await call.message.answer("📄 Список заказов", reply_markup=keyboard)
+
+
+@router.callback_query(IsAdmin(), F.data.startswith("orders_page:"))
+async def paginate_orders(call: CallbackQuery, session: AsyncSession) -> None:
+    """Хендлер переключения страниц списка заказов."""
+
+    page = int(call.data.split(":")[1])
+    keyboard = await get_order_list_menu_keyboard(session=session, page=page)
+
+    await call.message.edit_reply_markup(reply_markup=keyboard)
+    await call.answer()
+
+
+@router.callback_query(IsAdmin(), F.data.startswith("order_preview:"))
+async def show_order_preview(call: CallbackQuery, session: AsyncSession) -> None:
+    """Хендлер детального просмотра заказа."""
+
+    order_id = int(call.data.split(":")[1])
+    order = await OrderManager.get_order(session=session, order_id=order_id)
+
+    if order is None:
+        await call.answer("❌ Заказ не найден", show_alert=True)
+        return
+
+    text = build_order_preview_text(order)
+    keyboard = order_status_keyboard(
+        order_id=order.id, current_status=order.status
+    )
+
+    await call.answer()
+    await call.message.answer(text, reply_markup=keyboard)
+
+
+@router.callback_query(IsAdmin(), F.data.startswith("order_status:"))
+async def change_order_status(call: CallbackQuery, session: AsyncSession) -> None:
+    """Хендлер изменения статуса заказа."""
+
+    _, order_raw, status_raw = call.data.split(":")
+    order_id = int(order_raw)
+
+    try:
+        new_status = OrderStatus(status_raw)
+    except ValueError:
+        await call.answer("❌ Неизвестный статус", show_alert=True)
+        return
+
+    updated = await OrderManager.update_order(
+        session=session,
+        order_id=order_id,
+        payload=UpdateOrder(status=new_status),
+    )
+
+    if updated is None:
+        await call.answer("❌ Заказ не найден", show_alert=True)
+        return
+
+    order = await OrderManager.get_order(session=session, order_id=order_id)
+    if order is None:
+        order = updated
+
+    text = build_order_preview_text(order)
+    keyboard = order_status_keyboard(
+        order_id=order_id, current_status=order.status
+    )
+
+    try:
+        await call.message.edit_text(text, reply_markup=keyboard)
+    except TelegramBadRequest:
+        logger.debug("Не удалось обновить сообщение заказа", exc_info=True)
+
+    status_title = STATUS_TITLES.get(new_status, new_status.value)
+    if order.tg_id:
+        try:
+            await call.bot.send_message(
+                order.tg_id,
+                (
+                    f"ℹ️ Статус вашего заказа {order.order_number} обновлён:\n"
+                    f"<b>{status_title}</b>"
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Не удалось отправить уведомление пользователю %s",
+                order.tg_id,
+                exc_info=True,
+            )
+
+    await call.answer("Статус заказа обновлён.")
+
+
+@router.callback_query(IsAdmin(), F.data.startswith("order_status_ignore:"))
+async def ignore_order_status(call: CallbackQuery) -> None:
+    """Хендлер для уже установленного статуса заказа."""
+
+    await call.answer("Этот статус уже установлен.")
 
 
 @router.callback_query(IsAdmin(), AddNewItem.confirm, F.data == "add_new_item_confirm")

--- a/tele_store/handlers/callback/user_callbacks.py
+++ b/tele_store/handlers/callback/user_callbacks.py
@@ -2,26 +2,31 @@ from __future__ import annotations
 
 import logging
 import secrets
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from aiogram import F, Router
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery
 
+from tele_store.crud.cart import CartManager
 from tele_store.crud.category import CategoryManager
 from tele_store.crud.order import OrderManager
 from tele_store.crud.product import ProductManager
 from tele_store.keyboards.inline.cancel_button import cancel_key
+from tele_store.keyboards.inline.cart_menu import build_cart_keyboard
 from tele_store.keyboards.inline.product_order_menu import product_order_keyboard
 from tele_store.keyboards.inline.user_category_menu import get_user_category_keyboard
 from tele_store.keyboards.inline.user_product_menu import get_user_product_keyboard
 from tele_store.keyboards.inline.order_confirm_menu import order_confirm_keyboard
+from tele_store.schemas.cart import AddCartItem, UpdateCartItemCount
 from tele_store.schemas.order import CreateOrder, CreateOrderItem
 from tele_store.states.states import NewDelivery
 
 if TYPE_CHECKING:
-    from decimal import Decimal
     from sqlalchemy.ext.asyncio import AsyncSession
+    from tele_store.models.models import Cart
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -31,6 +36,122 @@ def generate_order_number() -> str:
     """Сгенерировать короткий номер заказа."""
 
     return secrets.token_hex(4).upper()
+
+
+MONEY_STEP = Decimal("0.01")
+
+
+def format_money(amount: Decimal) -> str:
+    """Отформатировать цену для отображения пользователю."""
+
+    return f"{amount.quantize(MONEY_STEP)} ₽"
+
+
+def collect_cart_lines(cart: Cart) -> tuple[list[str], Decimal]:
+    """Собрать список строк с содержимым корзины и подсчитать сумму."""
+
+    total = Decimal("0")
+    lines: list[str] = []
+
+    for index, item in enumerate(cart.items, start=1):
+        product = item.product
+        if product is None:
+            continue
+
+        line_total = product.price * item.quantity
+        total += line_total
+        lines.append(
+            f"{index}. {product.name} — {item.quantity} шт. × "
+            f"{format_money(product.price)} = {format_money(line_total)}"
+        )
+
+    return lines, total
+
+
+def build_cart_text(cart: Cart) -> str:
+    """Подготовить текстовое представление корзины."""
+
+    lines, total = collect_cart_lines(cart)
+    if not lines:
+        return "🛒 Сейчас ваша корзина пуста."
+
+    items_text = "\n".join(lines)
+    return (
+        "🛒 <b>Ваша корзина</b>\n\n"
+        f"{items_text}\n\n"
+        f"Итого: <b>{format_money(total)}</b>\n"
+        "Используйте кнопки ниже, чтобы изменить корзину или оформить заказ."
+    )
+
+
+def build_order_preview_text(cart: Cart, data: dict[str, object]) -> str:
+    """Сформировать текст подтверждения заказа."""
+
+    lines, total = collect_cart_lines(cart)
+    items_text = "\n".join(lines) if lines else "Корзина пуста"
+
+    return (
+        "📦 <b>Проверьте данные заказа</b>\n\n"
+        f"{items_text}\n\n"
+        f"Итого: <b>{format_money(total)}</b>\n\n"
+        f"Имя: {data.get('name', '—')}\n"
+        f"Телефон: {data.get('phone_number', '—')}\n"
+        f"Адрес: {data.get('address', '—')}\n"
+        f"Доставка: {data.get('delivery_method', '—')}\n\n"
+        "Если всё верно — подтвердите оформление."
+    )
+
+
+async def sanitize_cart(
+    session: "AsyncSession", cart: Cart
+) -> Cart | None:
+    """Удалить из корзины недоступные товары и вернуть актуальную корзину."""
+
+    removed = False
+    for item in list(cart.items):
+        product = item.product
+        if product is None or not getattr(product, "is_active", True):
+            await CartManager.delete_cart_item(session, item.id)
+            removed = True
+
+    if removed:
+        return await CartManager.get_cart_by_user(
+            session=session, tg_id=cart.tg_id
+        )
+    return cart
+
+
+async def refresh_cart_view(
+    call: CallbackQuery, session: "AsyncSession"
+) -> Cart | None:
+    """Перерисовать сообщение с корзиной."""
+
+    cart = await CartManager.get_cart_by_user(
+        session=session, tg_id=call.from_user.id
+    )
+    if cart is None:
+        try:
+            await call.message.edit_text("🛒 Сейчас ваша корзина пуста.")
+        except TelegramBadRequest:
+            logger.debug("Не удалось обновить сообщение корзины", exc_info=True)
+        return None
+
+    cart = await sanitize_cart(session, cart) or cart
+    if not cart.items:
+        try:
+            await call.message.edit_text("🛒 Сейчас ваша корзина пуста.")
+        except TelegramBadRequest:
+            logger.debug("Не удалось обновить сообщение корзины", exc_info=True)
+        return None
+
+    text = build_cart_text(cart)
+    keyboard = build_cart_keyboard(cart)
+    try:
+        await call.message.edit_text(text, reply_markup=keyboard)
+    except TelegramBadRequest:
+        logger.debug("Не удалось обновить сообщение корзины", exc_info=True)
+
+    return cart
 
 
 @router.callback_query(F.data == "catalog")
@@ -168,144 +289,336 @@ async def show_product_preview(call: CallbackQuery, session: AsyncSession) -> No
 
 
 @router.callback_query(F.data == "cart")
-async def open_cart(call: CallbackQuery) -> None:
-    """Сообщить пользователю о временном отсутствии корзины."""
+async def open_cart(call: CallbackQuery, session: AsyncSession) -> None:
+    """Показать пользователю содержимое корзины."""
 
-    await call.answer("Корзина будет доступна позже.", show_alert=True)
+    cart = await CartManager.get_cart_by_user(
+        session=session, tg_id=call.from_user.id
+    )
+    cleaned_cart = await sanitize_cart(session, cart) if cart else cart
+
+    if cleaned_cart is None or not cleaned_cart.items:
+        await call.answer("Сейчас корзина пуста.", show_alert=True)
+        return
+
+    if cleaned_cart is not cart:
+        await call.answer(
+            "Некоторые товары больше недоступны и были убраны из корзины.",
+            show_alert=True,
+        )
+    else:
+        await call.answer()
+
+    text = build_cart_text(cleaned_cart)
+    keyboard = build_cart_keyboard(cleaned_cart)
+    await call.message.answer(text, reply_markup=keyboard)
 
 
 @router.callback_query(F.data == "cancel_order")
 async def cancel_order(call: CallbackQuery, state: FSMContext) -> None:
-    """Отменить оформление заказа на этапе подтверждения."""
+    """Отменить оформление заказа и очистить состояние."""
 
-    if await state.get_state() == NewDelivery.confirm.state:
+    if await state.get_state() is not None:
         await state.clear()
-    await call.message.edit_text("❌ Оформление заказа отменено.")
+    try:
+        await call.message.edit_text(
+            "❌ Оформление заказа отменено. Корзина сохранена, можно продолжить покупки."
+        )
+    except TelegramBadRequest:
+        logger.debug("Не удалось обновить сообщение при отмене заказа", exc_info=True)
     await call.answer()
 
 
-@router.callback_query(F.data.startswith("order_product:"))
-async def start_order(
-    call: CallbackQuery, session: AsyncSession, state: FSMContext
-) -> None:
-    """Запустить процесс оформления заказа для выбранного товара."""
+@router.callback_query(F.data.startswith("add_to_cart:"))
+async def add_product_to_cart(call: CallbackQuery, session: AsyncSession) -> None:
+    """Добавить выбранный товар в корзину пользователя."""
 
     product_id = int(call.data.split(":")[1])
     product = await ProductManager.get_product(session=session, product_id=product_id)
 
     if product is None or not product.is_active:
-        await call.answer("Товар недоступен для заказа.", show_alert=True)
+        await call.answer("Товар недоступен для добавления.", show_alert=True)
+        return
+
+    cart = await CartManager.get_cart_by_user(
+        session=session, tg_id=call.from_user.id
+    )
+    if cart is None:
+        cart = await CartManager.create_cart(session=session, tg_id=call.from_user.id)
+
+    existing_item = await CartManager.get_cart_item_by_product(
+        session=session, cart_id=cart.id, product_id=product.id
+    )
+
+    if existing_item is None:
+        await CartManager.add_cart_item(
+            session=session,
+            payload=AddCartItem(cart_id=cart.id, product_id=product.id, quantity=1),
+        )
+    else:
+        await CartManager.update_cart_item_count(
+            session=session,
+            payload=UpdateCartItemCount(
+                cart_item_id=existing_item.id,
+                quantity=existing_item.quantity + 1,
+            ),
+        )
+
+    await call.answer("Добавлено в корзину!")
+
+
+@router.callback_query(F.data.startswith("cart_increase:"))
+async def increase_cart_item(call: CallbackQuery, session: AsyncSession) -> None:
+    """Увеличить количество товара в корзине."""
+
+    item_id = int(call.data.split(":")[1])
+    cart_item = await CartManager.get_cart_item(
+        session=session, cart_item_id=item_id
+    )
+
+    if cart_item is None or cart_item.cart.tg_id != call.from_user.id:
+        await call.answer("Товар не найден в корзине.", show_alert=True)
+        return
+
+    await CartManager.update_cart_item_count(
+        session=session,
+        payload=UpdateCartItemCount(
+            cart_item_id=cart_item.id,
+            quantity=cart_item.quantity + 1,
+        ),
+    )
+
+    await refresh_cart_view(call, session)
+    await call.answer("Количество увеличено.")
+
+
+@router.callback_query(F.data.startswith("cart_decrease:"))
+async def decrease_cart_item(call: CallbackQuery, session: AsyncSession) -> None:
+    """Уменьшить количество товара в корзине."""
+
+    item_id = int(call.data.split(":")[1])
+    cart_item = await CartManager.get_cart_item(
+        session=session, cart_item_id=item_id
+    )
+
+    if cart_item is None or cart_item.cart.tg_id != call.from_user.id:
+        await call.answer("Товар не найден в корзине.", show_alert=True)
+        return
+
+    new_quantity = cart_item.quantity - 1
+    if new_quantity <= 0:
+        await CartManager.delete_cart_item(session=session, cart_item_id=cart_item.id)
+        await refresh_cart_view(call, session)
+        await call.answer("Товар удалён из корзины.")
+        return
+
+    await CartManager.update_cart_item_count(
+        session=session,
+        payload=UpdateCartItemCount(
+            cart_item_id=cart_item.id,
+            quantity=new_quantity,
+        ),
+    )
+
+    await refresh_cart_view(call, session)
+    await call.answer("Количество уменьшено.")
+
+
+@router.callback_query(F.data.startswith("cart_remove:"))
+async def remove_cart_item(call: CallbackQuery, session: AsyncSession) -> None:
+    """Удалить выбранный товар из корзины."""
+
+    item_id = int(call.data.split(":")[1])
+    cart_item = await CartManager.get_cart_item(
+        session=session, cart_item_id=item_id
+    )
+
+    if cart_item is None or cart_item.cart.tg_id != call.from_user.id:
+        await call.answer("Товар уже отсутствует в корзине.", show_alert=True)
+        return
+
+    await CartManager.delete_cart_item(session=session, cart_item_id=cart_item.id)
+    await refresh_cart_view(call, session)
+    await call.answer("Товар удалён.")
+
+
+@router.callback_query(F.data == "cart_clear")
+async def clear_cart(call: CallbackQuery, session: AsyncSession) -> None:
+    """Полностью очистить корзину пользователя."""
+
+    cart = await CartManager.get_cart_by_user(
+        session=session, tg_id=call.from_user.id
+    )
+    if cart is None or not cart.items:
+        await call.answer("Корзина уже пуста.", show_alert=True)
+        return
+
+    await CartManager.clear_cart(session=session, cart_id=cart.id)
+    await refresh_cart_view(call, session)
+    await call.answer("Корзина очищена.")
+
+
+@router.callback_query(F.data.startswith("cart_ignore:"))
+async def ignore_cart_info(call: CallbackQuery) -> None:
+    """Обработать нажатие на неактивную кнопку количества."""
+
+    await call.answer()
+
+
+@router.callback_query(F.data == "checkout_cart")
+async def start_checkout(
+    call: CallbackQuery, session: AsyncSession, state: FSMContext
+) -> None:
+    """Запустить процесс оформления заказа из корзины."""
+
+    cart = await CartManager.get_cart_by_user(
+        session=session, tg_id=call.from_user.id
+    )
+    if cart is None or not cart.items:
+        await call.answer("Корзина пуста. Добавьте товары перед оформлением.", show_alert=True)
+        await refresh_cart_view(call, session)
+        return
+
+    cleaned_cart = await sanitize_cart(session, cart) or cart
+    if cleaned_cart is None or not cleaned_cart.items:
+        await call.answer(
+            "В корзине не осталось доступных товаров. Добавьте новые позиции.",
+            show_alert=True,
+        )
+        await refresh_cart_view(call, session)
         return
 
     await state.clear()
     await state.set_state(NewDelivery.name)
-    await state.update_data(
-        product_id=product.id,
-        product_name=product.name,
-        product_price=str(product.price),
-    )
+    await state.update_data(cart_id=cleaned_cart.id)
 
-    await call.message.answer(
-        "Отличный выбор! Давай оформим заказ. Как к тебе обращаться?",
-        reply_markup=cancel_key(),
-    )
     await call.answer()
+    try:
+        await call.message.edit_text(
+            "Отличный выбор! Давай оформим заказ. Как к тебе обращаться?",
+            reply_markup=cancel_key(),
+        )
+    except TelegramBadRequest:
+        logger.debug("Не удалось обновить сообщение корзины перед оформлением", exc_info=True)
+        await call.message.answer(
+            "Отличный выбор! Давай оформим заказ. Как к тебе обращаться?",
+            reply_markup=cancel_key(),
+        )
+
 
 @router.callback_query(
     NewDelivery.delivery_method,
     F.data.in_(["select_courier", "select_self-delivery"])
 )
-async def confirm_order(
+async def choose_delivery_method(
     call: CallbackQuery, session: AsyncSession, state: FSMContext
 ) -> None:
-    """Получить желаемый метод доставки."""
+    """Получить желаемый способ доставки перед подтверждением заказа."""
 
     delivery_method = (
         "Курьер" if call.data == "select_courier" else "Самовывоз"
     )
 
-    if not delivery_method:
-        await call.message.answer(
-            "❌ Нужно указать способ доставки. Например: курьером или самовывоз.",
-            reply_markup=cancel_key(),
-        )
-        return
-
     await state.update_data(delivery_method=delivery_method)
     await state.set_state(NewDelivery.confirm)
-    await call.answer()
 
     data = await state.get_data()
-    product_name = data.get("product_name", "—")
-    product_price: Decimal | str | None = data.get("product_price")
-    price_text = str(product_price) if product_price is not None else "—"
+    cart_id = data.get("cart_id")
 
-    preview = (
-        "📦 <b>Проверьте данные заказа</b>\n\n"
-        f"Товар: {product_name}\n"
-        f"Стоимость: {price_text} ₽\n\n"
-        f"Имя: {data.get('name')}\n"
-        f"Телефон: {data.get('phone_number')}\n"
-        f"Адрес: {data.get('address')}\n"
-        f"Доставка: {delivery_method}\n\n"
-        "Если всё верно — подтвердите оформление."
-    )
+    if cart_id is None:
+        await state.clear()
+        await call.message.answer(
+            "❌ Корзина не найдена. Попробуйте начать оформление заново.",
+            reply_markup=cancel_key(),
+        )
+        await call.answer(show_alert=True)
+        return
 
+    cart = await CartManager.get_cart(session=session, cart_id=int(cart_id))
+    cart = await sanitize_cart(session, cart) if cart else cart
+
+    if cart is None or not cart.items:
+        await state.clear()
+        await call.message.answer(
+            "❌ Корзина пуста. Добавьте товары и начните оформление заново.",
+        )
+        await call.answer(show_alert=True)
+        return
+
+    preview = build_order_preview_text(cart, data)
+    await call.answer()
     await call.message.answer(preview, reply_markup=order_confirm_keyboard())
+
 
 @router.callback_query(NewDelivery.confirm, F.data == "confirm_order")
 async def confirm_order(
     call: CallbackQuery, session: AsyncSession, state: FSMContext
 ) -> None:
-    """Подтвердить заказ и сохранить его в базе."""
+    """Подтвердить заказ из корзины и сохранить его в базе."""
 
     data = await state.get_data()
-    product_id_raw = data.get("product_id")
-    if product_id_raw is None:
+    cart_id = data.get("cart_id")
+
+    if cart_id is None:
         await state.clear()
         await call.message.edit_text(
-            "❌ Не удалось оформить заказ. Попробуйте выбрать товар ещё раз."
+            "❌ Не удалось найти корзину. Попробуйте оформить заказ заново."
         )
         await call.answer(show_alert=True)
         return
 
-    product_id = int(product_id_raw)
-    product = await ProductManager.get_product(session=session, product_id=product_id)
+    cart = await CartManager.get_cart(session=session, cart_id=int(cart_id))
+    cart = await sanitize_cart(session, cart) if cart else cart
 
-    if product is None or not product.is_active:
+    if cart is None or not cart.items:
         await state.clear()
         await call.message.edit_text(
-            "❌ Не удалось оформить заказ: выбранный товар больше недоступен."
+            "❌ Корзина пуста. Добавьте товары и попробуйте снова."
+        )
+        await call.answer(show_alert=True)
+        return
+
+    lines, total_price = collect_cart_lines(cart)
+    if not lines:
+        await state.clear()
+        await call.message.edit_text(
+            "❌ В корзине нет доступных товаров. Попробуйте добавить новые позиции."
         )
         await call.answer(show_alert=True)
         return
 
     order_number = generate_order_number()
-    price: Decimal = product.price
-
     order_payload = CreateOrder(
         order_number=order_number,
         tg_id=call.from_user.id,
-        total_price=price,
+        total_price=total_price,
         delivery_method=data.get("delivery_method"),
     )
 
     order = await OrderManager.create_order(session=session, payload=order_payload)
 
-    order_item_payload = CreateOrderItem(
-        order_id=order.id,
-        product_id=product.id,
-        quantity=1,
-        price=price,
-    )
+    for item in cart.items:
+        product = item.product
+        if product is None:
+            continue
+        await OrderManager.create_order_item(
+            session=session,
+            payload=CreateOrderItem(
+                order_id=order.id,
+                product_id=product.id,
+                quantity=item.quantity,
+                price=product.price,
+            ),
+        )
 
-    await OrderManager.create_order_item(session=session, payload=order_item_payload)
+    await CartManager.clear_cart(session=session, cart_id=cart.id)
 
+    items_text = "\n".join(lines)
     summary = (
         "✅ <b>Заказ оформлен!</b>\n\n"
         f"Номер заказа: <code>{order_number}</code>\n"
-        f"Товар: {product.name}\n"
-        f"Стоимость: {price} ₽\n\n"
+        f"{items_text}\n\n"
+        f"Итого: <b>{format_money(total_price)}</b>\n\n"
         f"Имя: {data.get('name')}\n"
         f"Телефон: {data.get('phone_number')}\n"
         f"Адрес: {data.get('address')}\n"

--- a/tele_store/keyboards/inline/cart_menu.py
+++ b/tele_store/keyboards/inline/cart_menu.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from tele_store.models.models import Cart
+
+
+def build_cart_keyboard(cart: Cart) -> InlineKeyboardMarkup:
+    """Собрать клавиатуру управления корзиной."""
+
+    builder = InlineKeyboardBuilder()
+
+    for item in cart.items:
+        product_name = (
+            item.product.name if item.product is not None else f"ID {item.product_id}"
+        )
+        builder.row(
+            InlineKeyboardButton(
+                text="➖",
+                callback_data=f"cart_decrease:{item.id}",
+            ),
+            InlineKeyboardButton(
+                text=f"{item.quantity}",
+                callback_data=f"cart_ignore:{item.id}",
+            ),
+            InlineKeyboardButton(
+                text="➕",
+                callback_data=f"cart_increase:{item.id}",
+            ),
+        )
+        builder.row(
+            InlineKeyboardButton(
+                text=f"🗑 Удалить {product_name[:20]}",
+                callback_data=f"cart_remove:{item.id}",
+            )
+        )
+
+    if cart.items:
+        builder.row(
+            InlineKeyboardButton(
+                text="🧾 Оформить заказ",
+                callback_data="checkout_cart",
+            )
+        )
+        builder.row(
+            InlineKeyboardButton(
+                text="🧹 Очистить корзину",
+                callback_data="cart_clear",
+            )
+        )
+
+    builder.row(
+        InlineKeyboardButton(
+            text="⬅️ Назад к категориям",
+            callback_data="back_to_categories",
+        )
+    )
+    builder.row(
+        InlineKeyboardButton(
+            text="❌ Закрыть",
+            callback_data="cancel",
+        )
+    )
+
+    return builder.as_markup()

--- a/tele_store/keyboards/inline/order_list_menu.py
+++ b/tele_store/keyboards/inline/order_list_menu.py
@@ -7,6 +7,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from tele_store.config.config_reader import config
 from tele_store.crud.order import OrderManager
+from tele_store.keyboards.inline.order_status_menu import STATUS_TITLES
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,9 +25,10 @@ async def get_order_list_menu_keyboard(
     page_orders = order_list[start:end]
 
     for order in page_orders:
+        status_title = STATUS_TITLES.get(order.status, str(order.status))
         builder.row(
             InlineKeyboardButton(
-                text=f"{order.order_number}",
+                text=f"{order.order_number} · {status_title}",
                 callback_data=f"order_preview:{order.id}",
             )
         )
@@ -38,11 +40,15 @@ async def get_order_list_menu_keyboard(
 
     if page > 1:
         pagination_buttons.append(
-            InlineKeyboardButton(text="⬅️ Назад", callback_data=f"page:{page - 1}")
+            InlineKeyboardButton(
+                text="⬅️ Назад", callback_data=f"orders_page:{page - 1}"
+            )
         )
     if page < total_pages:
         pagination_buttons.append(
-            InlineKeyboardButton(text="Вперёд ➡️", callback_data=f"page:{page + 1}")
+            InlineKeyboardButton(
+                text="Вперёд ➡️", callback_data=f"orders_page:{page + 1}"
+            )
         )
 
     if pagination_buttons:

--- a/tele_store/keyboards/inline/order_status_menu.py
+++ b/tele_store/keyboards/inline/order_status_menu.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from tele_store.db.enums import OrderStatus
+
+STATUS_TITLES: dict[OrderStatus, str] = {
+    OrderStatus.NEW: "🆕 Новый",
+    OrderStatus.PROCESSING: "⚙️ В обработке",
+    OrderStatus.SHIPPED: "🚚 Отправлен",
+    OrderStatus.DELIVERED: "📦 Доставлен",
+    OrderStatus.CANCELED: "❌ Отменён",
+}
+
+
+def order_status_keyboard(
+    *, order_id: int, current_status: OrderStatus
+) -> InlineKeyboardMarkup:
+    """Собрать клавиатуру для смены статуса заказа."""
+
+    builder = InlineKeyboardBuilder()
+
+    for status, title in STATUS_TITLES.items():
+        if status == current_status:
+            button_text = f"✅ {title}"
+            callback_data = f"order_status_ignore:{order_id}"
+        else:
+            button_text = title
+            callback_data = f"order_status:{order_id}:{status.value}"
+
+        builder.row(InlineKeyboardButton(text=button_text, callback_data=callback_data))
+
+    builder.row(
+        InlineKeyboardButton(
+            text="⬅️ К списку заказов",
+            callback_data="orders_list",
+        )
+    )
+    builder.row(
+        InlineKeyboardButton(
+            text="❌ Закрыть",
+            callback_data="cancel",
+        )
+    )
+
+    return builder.as_markup()

--- a/tele_store/keyboards/inline/product_order_menu.py
+++ b/tele_store/keyboards/inline/product_order_menu.py
@@ -16,8 +16,15 @@ def product_order_keyboard(
 
     builder.row(
         InlineKeyboardButton(
-            text="🛍 Оформить заказ",
-            callback_data=f"order_product:{product_id}",
+            text="➕ Добавить в корзину",
+            callback_data=f"add_to_cart:{product_id}",
+        )
+    )
+
+    builder.row(
+        InlineKeyboardButton(
+            text="🛒 Перейти в корзину",
+            callback_data="cart",
         )
     )
 

--- a/tele_store/schemas/order.py
+++ b/tele_store/schemas/order.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from decimal import Decimal
 
 from pydantic import BaseModel


### PR DESCRIPTION
## Summary
- add a full cart flow with persistence utilities, interactive cart controls, and checkout that creates orders from all basket items
- switch product actions to add-to-cart buttons and expose cart management UI for customers before confirming delivery details
- let admins open detailed order previews, update statuses through inline buttons, and automatically notify buyers about status changes

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6648ccf78832a9817a6a69e59f110